### PR TITLE
切断过长的错误信息

### DIFF
--- a/smsserver/models/sms_center.py
+++ b/smsserver/models/sms_center.py
@@ -131,7 +131,14 @@ class SMSProvider(BaseModel):
             else:
                 ret = api_client.send_voice(country_code, phone_number, text)
         except SMSSendFailed as e:
-            record.status, record.error_msg = SMSSendStatus.failed, e.message
+            # record.error_msg 最长 128，切掉尾巴
+            if isinstance(e.message, str):
+                error_msg = e.message.decode('utf-8')
+            else:
+                error_msg = e.message
+            if len(error_msg) > 128:
+                error_msg = u"{}...".format(error_msg[:125])
+            record.status, record.error_msg = SMSSendStatus.failed, error_msg
             record.save()
             raise e
         else:


### PR DESCRIPTION
Sentry 报错：[DataError: (1406, "Data too long for column 'error_msg' at row 1")](http://sentry.xiachufang.com/sentry/sms/issues/6743/)